### PR TITLE
Cherry-Pick upstream fixes to 1.9.6

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -149,7 +149,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
         LOGGER.info("Read xlogStart at '{}' from transaction '{}'", xlogStart, txId);
 
         // use the old xmin, as we don't want to update it if in xmin recovery
-        offset.updateWalPosition(xlogStart, offset.lastCompletelyProcessedLsn(), clock.currentTime(), txId, offset.xmin(), null);
+        offset.updateWalPosition(xlogStart, offset.lastCompletelyProcessedLsn(), clock.currentTime(), txId, offset.xmin(), null, null);
     }
 
     protected void updateOffsetForPreSnapshotCatchUpStreaming(PostgresOffsetContext offset) throws SQLException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -75,8 +75,9 @@ public class WalPositionLocator {
             // We can resume streaming from it
             if (currentLsn.equals(lastEventStoredLsn)) {
                 // BEGIN and first message after change have the same LSN
-                if (txStartLsn != null && (lastProcessedMessageType == null || lastProcessedMessageType == Operation.BEGIN)) {
-                    // start from the BEGIN tx; prevent skipping of unprocessed event after BEGIN
+                if (txStartLsn != null
+                        && (lastProcessedMessageType == null || lastProcessedMessageType == Operation.BEGIN || lastProcessedMessageType == Operation.COMMIT)) {
+                    // start from the BEGIN tx; prevent skipping of unprocessed event after BEGIN or previsou tx COMMIT
                     LOGGER.info("Will restart from LSN '{}' corresponding to the event following the BEGIN event", txStartLsn);
                     startStreamingLsn = txStartLsn;
                     return Optional.of(startStreamingLsn);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.connector.postgresql.connection.ReplicationMessage.Operation;
 
 /**
  * This class is responsible for finding out a LSN from which Debezium should
@@ -30,6 +31,7 @@ public class WalPositionLocator {
 
     private final Lsn lastCommitStoredLsn;
     private final Lsn lastEventStoredLsn;
+    private final Operation lastProcessedMessageType;
     private Lsn txStartLsn = null;
     private Lsn lsnAfterLastEventStoredLsn = null;
     private Lsn firstLsnReceived = null;
@@ -38,9 +40,10 @@ public class WalPositionLocator {
     private boolean storeLsnAfterLastEventStoredLsn = false;
     private Set<Lsn> lsnSeen = new HashSet<>(1_000);
 
-    public WalPositionLocator(Lsn lastCommitStoredLsn, Lsn lastEventStoredLsn) {
+    public WalPositionLocator(Lsn lastCommitStoredLsn, Lsn lastEventStoredLsn, Operation lastProcessedMessageType) {
         this.lastCommitStoredLsn = lastCommitStoredLsn;
         this.lastEventStoredLsn = lastEventStoredLsn;
+        this.lastProcessedMessageType = lastProcessedMessageType;
 
         LOGGER.info("Looking for WAL restart position for last commit LSN '{}' and last change LSN '{}'",
                 lastCommitStoredLsn, lastEventStoredLsn);
@@ -49,6 +52,7 @@ public class WalPositionLocator {
     public WalPositionLocator() {
         this.lastCommitStoredLsn = null;
         this.lastEventStoredLsn = null;
+        this.lastProcessedMessageType = null;
 
         LOGGER.info("WAL position will not be searched");
     }
@@ -71,6 +75,12 @@ public class WalPositionLocator {
             // We can resume streaming from it
             if (currentLsn.equals(lastEventStoredLsn)) {
                 // BEGIN and first message after change have the same LSN
+                if (txStartLsn != null && (lastProcessedMessageType == null || lastProcessedMessageType == Operation.BEGIN)) {
+                    // start from the BEGIN tx; prevent skipping of unprocessed event after BEGIN
+                    LOGGER.info("Will restart from LSN '{}' corresponding to the event following the BEGIN event", txStartLsn);
+                    startStreamingLsn = txStartLsn;
+                    return Optional.of(startStreamingLsn);
+                }
                 return Optional.empty();
             }
             lsnAfterLastEventStoredLsn = currentLsn;
@@ -171,12 +181,16 @@ public class WalPositionLocator {
         return lastEventStoredLsn;
     }
 
+    public Lsn getLastCommitStoredLsn() {
+        return lastCommitStoredLsn;
+    }
+
     @Override
     public String toString() {
         return "WalPositionLocator [lastCommitStoredLsn=" + lastCommitStoredLsn + ", lastEventStoredLsn="
-                + lastEventStoredLsn + ", txStartLsn=" + txStartLsn + ", lsnAfterLastEventStoredLsn="
-                + lsnAfterLastEventStoredLsn + ", firstLsnReceived=" + firstLsnReceived + ", passMessages="
-                + passMessages + ", startStreamingLsn=" + startStreamingLsn + ", storeLsnAfterLastEventStoredLsn="
-                + storeLsnAfterLastEventStoredLsn + "]";
+                + lastEventStoredLsn + ", lastProcessedMessageType=" + lastProcessedMessageType + ", txStartLsn="
+                + txStartLsn + ", lsnAfterLastEventStoredLsn=" + lsnAfterLastEventStoredLsn + ", firstLsnReceived="
+                + firstLsnReceived + ", passMessages=" + passMessages + ", startStreamingLsn=" + startStreamingLsn
+                + ", storeLsnAfterLastEventStoredLsn=" + storeLsnAfterLastEventStoredLsn + "]";
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -133,11 +133,17 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
             switch (type) {
                 case TYPE:
                 case ORIGIN:
-                case TRUNCATE:
-                    // TYPE/ORIGIN/TRUNCATE
+                    // TYPE/ORIGIN
                     // These should be skipped without calling shouldMessageBeSkipped. DBZ-5792
                     LOGGER.trace("{} messages are always skipped without calling shouldMessageBeSkipped", type);
                     return true;
+                case TRUNCATE:
+                    if (!isTruncateEventsIncluded()) {
+                        LOGGER.trace("{} messages are being skipped without calling shouldMessageBeSkipped", type);
+                        return true;
+                    }
+                    // else delegate to super.shouldMessageBeSkipped
+                    break;
                 default:
                     // call super.shouldMessageBeSkipped for rest of the types
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -130,6 +130,17 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         try {
             MessageType type = MessageType.forType((char) buffer.get());
             LOGGER.trace("Message Type: {}", type);
+            switch (type) {
+                case TYPE:
+                case ORIGIN:
+                case TRUNCATE:
+                    // TYPE/ORIGIN/TRUNCATE
+                    // These should be skipped without calling shouldMessageBeSkipped. DBZ-5792
+                    LOGGER.trace("{} messages are always skipped without calling shouldMessageBeSkipped", type);
+                    return true;
+                default:
+                    // call super.shouldMessageBeSkipped for rest of the types
+            }
             final boolean candidateForSkipping = super.shouldMessageBeSkipped(buffer, lastReceivedLsn, startLsn, walPosition);
             switch (type) {
                 case COMMIT:
@@ -147,7 +158,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                     LOGGER.trace("{} messages are always reprocessed", type);
                     return false;
                 default:
-                    // INSERT/UPDATE/DELETE/TRUNCATE/TYPE/ORIGIN/LOGICAL_DECODING_MESSAGE
+                    // INSERT/UPDATE/DELETE/LOGICAL_DECODING_MESSAGE
                     // These should be excluded based on the normal behavior, delegating to default method
                     return candidateForSkipping;
             }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/LegacyV1SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/LegacyV1SourceInfoTest.java
@@ -50,7 +50,7 @@ public class LegacyV1SourceInfoTest {
     @Test
     @FixFor("DBZ-934")
     public void canHandleNullValues() {
-        source.update(null, null, null, null, null);
+        source.update(null, null, null, null, null, null);
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
@@ -50,7 +50,7 @@ public class SourceInfoTest {
     @Test
     @FixFor("DBZ-934")
     public void canHandleNullValues() {
-        source.update(null, null, null, null, null);
+        source.update(null, null, null, null, null, null);
     }
 
     @Test


### PR DESCRIPTION
Cherry-Pick upstream fixes to 1.9.6:
- https://github.com/debezium/debezium/pull/4152
- https://github.com/debezium/debezium/pull/4357
- https://github.com/debezium/debezium/pull/4033

### How to build:
 - `cd debezium-connector-postgres`
 - `mvn clean verify -Dquick` # note that tests won't run for build
 - check `target` folder for jar files